### PR TITLE
canvasのError: /lib64/libz.so.1: version `ZLIB_1.2.9' not foundの解消

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,17 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-  experimental: {
+module.exports = () => {
+  reactStrictMode = true;
+  experimental = {
     esmExternals: false,
-  },
+  };
+  if (
+    process.env.LD_LIBRARY_PATH == null ||
+    !process.env.LD_LIBRARY_PATH.includes(
+      `${process.env.PWD}/node_modules/canvas/build/Release:`
+    )
+  ) {
+    process.env.LD_LIBRARY_PATH = `${
+      process.env.PWD
+    }/node_modules/canvas/build/Release:${process.env.LD_LIBRARY_PATH || ""}`;
+  }
 };
-
-module.exports = nextConfig;


### PR DESCRIPTION
## 問題点
- /api/ogpにアクセスすると500エラーが発生する

## 原因

```
2022-12-29T15:58:01.276Z	26a289b3-8720-47c3-bff6-4dc06c20551f	ERROR	Error: /lib64/libz.so.1: version `ZLIB_1.2.9' not found (required by /var/task/node_modules/canvas/build/Release/libpng16.so.16)
    at Module._extensions..node (node:internal/modules/cjs/loader:1243:18)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12)
    at Module.require (node:internal/modules/cjs/loader:1061:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/var/task/node_modules/canvas/lib/bindings.js:3:18)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12) {
  code: 'ERR_DLOPEN_FAILED'
}
RequestId: 26a289b3-8720-47c3-bff6-4dc06c20551f Error: Runtime exited with error: exit status 1
Runtime.ExitError
```